### PR TITLE
Linkaccount et relations entre Telegram users

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,13 @@ If you want to use docker, make sure it is installed on your machine, and then r
 You first have to register it on Telegram, for this follow the [documentation](https://core.telegram.org/bots).
 - Register your bot on BotFather
 - Register two commands:
-  - `help` which provides some help
-  - `recommendactors` which tries to recommend actors based on user preferences
+  - `help` - Provides some help to use the bot
+  - `recommendactors` - Tries to recommend actors based on user preferences
+  - `playeractivity` - Shows recent match activity for a given player
+  - `linkaccount` - Allows a Telegram user to link his Dota account
+  - `followplayer` - 
+  - `showfollowings` -
+  - `recommendhero` - 
 - run `/setinline` and `/setinlinefeedback` for the bot to be able to answer inline queries
 - copy the token the botfather gave you and go to `https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates`
   to enable active polling on your bot. Don't forget to replace `<YOUR_TOKEN>` by your actual token

--- a/src/DocumentDAO.js
+++ b/src/DocumentDAO.js
@@ -27,8 +27,16 @@ class DocumentDAO {
     return this.collection.insertOne(movie);
   }
 
+  insertUser(user) {
+    return this.collection.insertOne(user);
+  }
+
   getMovies(search) {
     return this.collection.find({ title: new RegExp(search) }).limit(10).toArray();
+  }
+
+  getRegisteredUsers(search) {
+    return this.collection.find({ username: new RegExp(search) }).limit(10).toArray();
   }
 
   getMovieById(id) {

--- a/src/GraphDAO.js
+++ b/src/GraphDAO.js
@@ -120,6 +120,17 @@ class GraphDAO {
     });
   }
 
+  upsertUserFollowed(userId, followedUsername) {
+    return this.run(`
+      MATCH (f:User {username: $followedUsername})
+        MERGE (u:User {id: $userId})
+        MERGE (u)-[r:FOLLOW]->(f)
+    `, {
+      userId,
+      followedUsername,
+    });
+  }
+
   upsertAdded(userId, movieId, added) {
     return this.run(`
       MATCH (m:Movie{ id: $movieId })

--- a/src/GraphDAO.js
+++ b/src/GraphDAO.js
@@ -104,19 +104,19 @@ class GraphDAO {
                     u.firstName = $firstName,
                     u.lastName = $lastName,
                     u.username = $username,
-                    u.languageCode = $languageCode
+                    u.personaname = $personaname
       ON MATCH SET  u.isBot = $isBot,
                     u.firstName = $firstName,
                     u.lastName = $lastName,
                     u.username = $username,
-                    u.languageCode = $languageCode
+                    u.personaname = $personaname
     `, {
       userId: this.toInt(user.id),
       firstName: user.first_name,
       lastName: user.last_name,
       username: user.username,
-      languageCode: user.language_code,
       isBot: user.is_bot,
+      personaname: user.personaname,
     });
   }
 

--- a/src/GraphDAO.js
+++ b/src/GraphDAO.js
@@ -131,6 +131,16 @@ class GraphDAO {
     });
   }
 
+  deleteUserFollowing(userId, followedUsername) {
+    return this.run(`
+      MATCH (User {id: $userId})-[r:FOLLOW]->(User {username: $followedUsername})
+      DELETE r
+    `, {
+      userId,
+      followedUsername,
+    });
+  }
+
   upsertAdded(userId, movieId, added) {
     return this.run(`
       MATCH (m:Movie{ id: $movieId })

--- a/src/index.js
+++ b/src/index.js
@@ -218,7 +218,7 @@ bot.command('playeractivity', (ctx) => {
   });
 });
 
-bot.command('registeraccount', (ctx) => {
+bot.command('linkaccount', (ctx) => {
   const msgText = ctx.message.text;
   const arguments = msgText.split(' ');
   let personaname;

--- a/src/index.js
+++ b/src/index.js
@@ -218,15 +218,20 @@ bot.command('playeractivity', (ctx) => {
   });
 });
 
+/**
+ * Réagis à la commande pour lier le compte Telegram au compte Dota (personaname)
+ * Usage : /linkaccount <personaname>
+ */
 bot.command('linkaccount', (ctx) => {
+  // Récupère la commande et parse le paramètre (personaname = nom du joueur)
   const msgText = ctx.message.text;
   const arguments = msgText.split(' ');
   let personaname;
   if (arguments[1] != null) {
     personaname = arguments[1];
   }
-  //console.log(personaname);
 
+  // Insère l'utilisateur dans la DB Graph
   graphDAO.upsertUser({
     first_name: 'unknown',
     last_name: 'unknown',
@@ -238,6 +243,26 @@ bot.command('linkaccount', (ctx) => {
   }).then(() => {
     ctx.reply(`Telegram user ${ctx.from.username} has been registered with dota account ${personaname}`);
   });
+});
+
+/**
+ * Réagis à la commande pour suivre un compte Telegram associé à un compte Dota
+ */
+bot.command('followplayer', (ctx) => {
+  // Récupère la commande et parse le paramètre (telegramUsername)
+  const msgText = ctx.message.text;
+  const arguments = msgText.split(' ');
+  let telegramUsername;
+  if (arguments[1] != null) {
+    telegramUsername = arguments[1];
+  }
+
+  // Enregistre la relation FOLLOWING entre 2 utilisateurs Telegram
+  graphDAO.upsertUserFollowed(ctx.from.id, telegramUsername).then(() => {
+    ctx.reply(`You are now following Telegram user ${telegramUsername} !`);
+  })
+
+  // TODO : Improve, afficher sous forme d'inline query comportant uniquement les utilisateurs du groupe enregistrés
 });
 
 // Initialize mongo connexion

--- a/src/index.js
+++ b/src/index.js
@@ -218,6 +218,28 @@ bot.command('playeractivity', (ctx) => {
   });
 });
 
+bot.command('registeraccount', (ctx) => {
+  const msgText = ctx.message.text;
+  const arguments = msgText.split(' ');
+  let personaname;
+  if (arguments[1] != null) {
+    personaname = arguments[1];
+  }
+  //console.log(personaname);
+
+  graphDAO.upsertUser({
+    first_name: 'unknown',
+    last_name: 'unknown',
+    is_bot: false,
+    username: 'unknown',
+    dotaAccount: 'unknownAccount',
+    ...ctx.from,
+    personaname,
+  }).then(() => {
+    ctx.reply(`Telegram user ${ctx.from.username} has been registered with dota account ${personaname}`);
+  });
+});
+
 // Initialize mongo connexion
 // before starting bot
 documentDAO.init().then(() => {

--- a/src/loadData.js
+++ b/src/loadData.js
@@ -9,13 +9,14 @@ const GraphDAO = require('./GraphDAO');
 
 dotenv.config();
 
-const buildUser = (id, username, first_name, last_name, language_code, is_bot) => ({
+const buildUser = (id, username, first_name, last_name, language_code, is_bot, personaname) => ({
   id,
   username,
   first_name,
   last_name,
   language_code,
   is_bot,
+  personaname,
 });
 
 const shuffle = (array) => {
@@ -38,11 +39,11 @@ const parseMovies = () => new Promise((resolve) => {
 });
 
 const users = [
-  buildUser(220987852, 'ovesco', 'guillaume', '', 'fr', false),
-  buildUser(136451861, 'thrudhvangr', 'christopher', '', 'fr', false),
-  buildUser(136451862, 'NukedFace', 'marcus', '', 'fr', false),
-  buildUser(136451863, 'lauralol', 'laura', '', 'fr', false),
-  buildUser(136451864, 'Saumonlecitron', 'jean-michel', '', 'fr', false),
+  buildUser(220987852, 'ovesco', 'guillaume', '', 'fr', false, 'sierra'),
+  buildUser(136451861, 'thrudhvangr', 'christopher', '', 'fr', false, 'sierra'),
+  buildUser(136451862, 'NukedFace', 'marcus', '', 'fr', false, 'sierra'),
+  buildUser(136451863, 'lauralol', 'laura', '', 'fr', false, 'sierra'),
+  buildUser(136451864, 'Saumonlecitron', 'jean-michel', 'fr', 'fr', false, 'sierra'),
 ];
 
 const graphDAO = new GraphDAO();


### PR DESCRIPTION
- [X] Ajout de la possibilité de lier son compte Telegram avec son compte Dota (ou un compte Dota quelconque)
- [x] Possibilité de "follow" un utilisateur Telegram (/followplayer <telegram username>)
- [x] Affichage sous forme d'inline query n'affichant que les utilisateurs enregistrés (/linkaccount) présents dans la discussion/le groupe
- [ ] Affichage des comptes suivis (/showfollowings)
- [ ] Suppression d'un following (/deletefollowing <telegram username>)